### PR TITLE
Switch syscall to syscalln

### DIFF
--- a/cfd/iFileOpenDialog.go
+++ b/cfd/iFileOpenDialog.go
@@ -163,11 +163,9 @@ func (fileOpenDialog *iFileOpenDialog) setIsMultiselect(isMultiselect bool) erro
 
 func (vtbl *iFileOpenDialogVtbl) getResults(objPtr unsafe.Pointer) (*iShellItemArray, error) {
 	var shellItemArray *iShellItemArray
-	ret, _, _ := syscall.Syscall(vtbl.GetResults,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.GetResults,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(&shellItemArray)),
-		0)
+		uintptr(unsafe.Pointer(&shellItemArray)))
 	return shellItemArray, hresultToError(ret)
 }
 

--- a/cfd/iFileOpenDialog.go
+++ b/cfd/iFileOpenDialog.go
@@ -1,12 +1,14 @@
+//go:build windows
 // +build windows
 
 package cfd
 
 import (
-	"github.com/go-ole/go-ole"
-	"github.com/harry1453/go-common-file-dialog/util"
 	"syscall"
 	"unsafe"
+
+	"github.com/go-ole/go-ole"
+	"github.com/harry1453/go-common-file-dialog/util"
 )
 
 var (

--- a/cfd/iShellItem.go
+++ b/cfd/iShellItem.go
@@ -40,8 +40,7 @@ func newIShellItem(path string) (*iShellItem, error) {
 
 func (vtbl *iShellItemVtbl) getDisplayName(objPtr unsafe.Pointer) (string, error) {
 	var ptr *uint16
-	ret, _, _ := syscall.Syscall(vtbl.GetDisplayName,
-		2,
+	ret, _, _ := syscall.SyscallN(vtbl.GetDisplayName,
 		uintptr(objPtr),
 		0x80058000, // SIGDN_FILESYSPATH
 		uintptr(unsafe.Pointer(&ptr)))

--- a/cfd/iShellItem.go
+++ b/cfd/iShellItem.go
@@ -1,11 +1,13 @@
+//go:build windows
 // +build windows
 
 package cfd
 
 import (
-	"github.com/go-ole/go-ole"
 	"syscall"
 	"unsafe"
+
+	"github.com/go-ole/go-ole"
 )
 
 var (

--- a/cfd/iShellItemArray.go
+++ b/cfd/iShellItemArray.go
@@ -1,11 +1,13 @@
-//+build windows
+//go:build windows
+// +build windows
 
 package cfd
 
 import (
-	"github.com/go-ole/go-ole"
 	"syscall"
 	"unsafe"
+
+	"github.com/go-ole/go-ole"
 )
 
 const (

--- a/cfd/iShellItemArray.go
+++ b/cfd/iShellItemArray.go
@@ -37,11 +37,9 @@ type iShellItemArrayVtbl struct {
 
 func (vtbl *iShellItemArrayVtbl) getCount(objPtr unsafe.Pointer) (uintptr, error) {
 	var count uintptr
-	ret, _, _ := syscall.Syscall(vtbl.GetCount,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.GetCount,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(&count)),
-		0)
+		uintptr(unsafe.Pointer(&count)))
 	if err := hresultToError(ret); err != nil {
 		return 0, err
 	}
@@ -50,8 +48,7 @@ func (vtbl *iShellItemArrayVtbl) getCount(objPtr unsafe.Pointer) (uintptr, error
 
 func (vtbl *iShellItemArrayVtbl) getItemAt(objPtr unsafe.Pointer, index uintptr) (string, error) {
 	var shellItem *iShellItem
-	ret, _, _ := syscall.Syscall(vtbl.GetItemAt,
-		2,
+	ret, _, _ := syscall.SyscallN(vtbl.GetItemAt,
 		uintptr(objPtr),
 		index,
 		uintptr(unsafe.Pointer(&shellItem)))

--- a/cfd/vtblCommonFunc.go
+++ b/cfd/vtblCommonFunc.go
@@ -1,13 +1,15 @@
+//go:build windows
 // +build windows
 
 package cfd
 
 import (
 	"fmt"
-	"github.com/go-ole/go-ole"
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/go-ole/go-ole"
 )
 
 func hresultToError(hr uintptr) error {
@@ -18,20 +20,15 @@ func hresultToError(hr uintptr) error {
 }
 
 func (vtbl *iUnknownVtbl) release(objPtr unsafe.Pointer) error {
-	ret, _, _ := syscall.Syscall(vtbl.Release,
-		0,
-		uintptr(objPtr),
-		0,
-		0)
+	ret, _, _ := syscall.SyscallN(vtbl.Release,
+		uintptr(objPtr))
 	return hresultToError(ret)
 }
 
 func (vtbl *iModalWindowVtbl) show(objPtr unsafe.Pointer, hwnd uintptr) error {
-	ret, _, _ := syscall.Syscall(vtbl.Show,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.Show,
 		uintptr(objPtr),
-		hwnd,
-		0)
+		hwnd)
 	return hresultToError(ret)
 }
 
@@ -57,8 +54,7 @@ func (vtbl *iFileDialogVtbl) setFileTypes(objPtr unsafe.Pointer, filters []FileF
 		}
 	}()
 
-	ret, _, _ := syscall.Syscall(vtbl.SetFileTypes,
-		2,
+	ret, _, _ := syscall.SyscallN(vtbl.SetFileTypes,
 		uintptr(objPtr),
 		uintptr(cFileTypes),
 		uintptr(unsafe.Pointer(&comDlgFilterSpecs[0])))
@@ -90,21 +86,17 @@ func (vtbl *iFileDialogVtbl) setFileTypes(objPtr unsafe.Pointer, filters []FileF
 // FOS_FORCEPREVIEWPANEON = 0x40000000,
 // FOS_SUPPORTSTREAMABLEITEMS = 0x80000000
 func (vtbl *iFileDialogVtbl) setOptions(objPtr unsafe.Pointer, options uint32) error {
-	ret, _, _ := syscall.Syscall(vtbl.SetOptions,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetOptions,
 		uintptr(objPtr),
-		uintptr(options),
-		0)
+		uintptr(options))
 	return hresultToError(ret)
 }
 
 func (vtbl *iFileDialogVtbl) getOptions(objPtr unsafe.Pointer) (uint32, error) {
 	var options uint32
-	ret, _, _ := syscall.Syscall(vtbl.GetOptions,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.GetOptions,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(&options)),
-		0)
+		uintptr(unsafe.Pointer(&options)))
 	return options, hresultToError(ret)
 }
 
@@ -130,11 +122,9 @@ func (vtbl *iFileDialogVtbl) setDefaultFolder(objPtr unsafe.Pointer, path string
 		return err
 	}
 	defer shellItem.vtbl.release(unsafe.Pointer(shellItem))
-	ret, _, _ := syscall.Syscall(vtbl.SetDefaultFolder,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetDefaultFolder,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(shellItem)),
-		0)
+		uintptr(unsafe.Pointer(shellItem)))
 	return hresultToError(ret)
 }
 
@@ -144,41 +134,32 @@ func (vtbl *iFileDialogVtbl) setFolder(objPtr unsafe.Pointer, path string) error
 		return err
 	}
 	defer shellItem.vtbl.release(unsafe.Pointer(shellItem))
-	ret, _, _ := syscall.Syscall(vtbl.SetFolder,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetFolder,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(shellItem)),
-		0)
+		uintptr(unsafe.Pointer(shellItem)))
 	return hresultToError(ret)
 }
 
 func (vtbl *iFileDialogVtbl) setTitle(objPtr unsafe.Pointer, title string) error {
 	titlePtr := ole.SysAllocString(title)
 	defer ole.SysFreeString(titlePtr)
-	ret, _, _ := syscall.Syscall(vtbl.SetTitle,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetTitle,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(titlePtr)),
-		0)
+		uintptr(unsafe.Pointer(titlePtr)))
 	return hresultToError(ret)
 }
 
 func (vtbl *iFileDialogVtbl) close(objPtr unsafe.Pointer) error {
-	ret, _, _ := syscall.Syscall(vtbl.Close,
-		1,
-		uintptr(objPtr),
-		0,
-		0)
+	ret, _, _ := syscall.SyscallN(vtbl.Close,
+		uintptr(objPtr))
 	return hresultToError(ret)
 }
 
 func (vtbl *iFileDialogVtbl) getResult(objPtr unsafe.Pointer) (*iShellItem, error) {
 	var shellItem *iShellItem
-	ret, _, _ := syscall.Syscall(vtbl.GetResult,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.GetResult,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(&shellItem)),
-		0)
+		uintptr(unsafe.Pointer(&shellItem)))
 	return shellItem, hresultToError(ret)
 }
 
@@ -195,11 +176,9 @@ func (vtbl *iFileDialogVtbl) getResultString(objPtr unsafe.Pointer) (string, err
 }
 
 func (vtbl *iFileDialogVtbl) setClientGuid(objPtr unsafe.Pointer, guid *ole.GUID) error {
-	ret, _, _ := syscall.Syscall(vtbl.SetClientGuid,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetClientGuid,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(guid)),
-		0)
+		uintptr(unsafe.Pointer(guid)))
 	return hresultToError(ret)
 }
 
@@ -209,30 +188,25 @@ func (vtbl *iFileDialogVtbl) setDefaultExtension(objPtr unsafe.Pointer, defaultE
 	}
 	defaultExtensionPtr := ole.SysAllocString(defaultExtension)
 	defer ole.SysFreeString(defaultExtensionPtr)
-	ret, _, _ := syscall.Syscall(vtbl.SetDefaultExtension,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetDefaultExtension,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(defaultExtensionPtr)),
-		0)
+		uintptr(unsafe.Pointer(defaultExtensionPtr)))
 	return hresultToError(ret)
 }
 
 func (vtbl *iFileDialogVtbl) setFileName(objPtr unsafe.Pointer, fileName string) error {
 	fileNamePtr := ole.SysAllocString(fileName)
 	defer ole.SysFreeString(fileNamePtr)
-	ret, _, _ := syscall.Syscall(vtbl.SetFileName,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetFileName,
 		uintptr(objPtr),
-		uintptr(unsafe.Pointer(fileNamePtr)),
-		0)
+		uintptr(unsafe.Pointer(fileNamePtr)))
 	return hresultToError(ret)
 }
 
 func (vtbl *iFileDialogVtbl) setSelectedFileFilterIndex(objPtr unsafe.Pointer, index uint) error {
-	ret, _, _ := syscall.Syscall(vtbl.SetFileTypeIndex,
-		1,
+	ret, _, _ := syscall.SyscallN(vtbl.SetFileTypeIndex,
 		uintptr(objPtr),
 		uintptr(index+1), // SetFileTypeIndex counts from 1
-		0)
+	)
 	return hresultToError(ret)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/harry1453/go-common-file-dialog
 
-go 1.13
+go 1.18
 
 require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/uuid v1.1.1
 )
+
+require golang.org/x/sys v0.1.0 // indirect


### PR DESCRIPTION
This needs go at least 1.18, which is the first with syscalln.
    
If we want to get stuck on 1.13, we can still fix it by increasing nargs (they were all 1 smaller than needed to be), but I don't think it's worth it, as it's more error-prone, and go 1.13 is ancient.

I have also included some formatting stuff that VSCode did, in an extra commit.

(Note that if both this and #12 is merged, `go mod tidy` also adds an extra line to go.mod)
    
Fixes #11